### PR TITLE
erase cytanb global declare

### DIFF
--- a/src/cytanb.lua
+++ b/src/cytanb.lua
@@ -366,6 +366,9 @@ local cytanb = (function ()
 			refTable[data] = true
 			local serData = {}
 			for k, v in pairs(data) do
+				if type(k) == 'number' then
+					k = cytanb.ArrayNumberTag .. k
+				end
 				if type(v) == 'number' and v < 0 then
 					serData[k .. cytanb.NegativeNumberTag] = tostring(v)
 				else
@@ -385,9 +388,18 @@ local cytanb = (function ()
 			local data = {}
 			for k, v in pairs(serData) do
 				if type(v) == 'string' and string.endsWith(k, cytanb.NegativeNumberTag) then
-					data[string.sub(k, 1, #k - #cytanb.NegativeNumberTag)] = tonumber(v)
-				else
-					data[k] = cytanb.TableFromSerializable(v)
+                    if k:startsWith(cytanb.ArrayNumberTag) then
+                        k = k:sub(1, #k - #cytanb.NegativeNumberTag)
+                        data[tonumber(k:sub(#cytanb.ArrayNumberTag + 1,#k))] = tonumber(v)
+                    else
+                        data[k:sub(1, #k - #cytanb.NegativeNumberTag)] = tonumber(v)
+                    end
+                else
+                    if k:startsWith(cytanb.ArrayNumberTag) then
+                        data[tonumber(k:sub(#cytanb.ArrayNumberTag + 1,#k))] = cytanb.TableFromSerializable(v)
+                    else
+                        data[k] = cytanb.TableFromSerializable(v)
+                    end
 				end
 			end
 			return data
@@ -448,6 +460,7 @@ local cytanb = (function ()
 		:SetConst('ColorBrightnessSamples', 5)
 		:SetConst('ColorMapSize', cytanb.ColorHueSamples * cytanb.ColorSaturationSamples * cytanb.ColorBrightnessSamples)
 		:SetConst('NegativeNumberTag', '#__CYTANB_NEGATIVE_NUMBER')
+		:SetConst('ArrayNumberTag', '#__CYTANB_ARRAY_NUMBER')
 		:SetConst('InstanceIDParameterName', '__CYTANB_INSTANCE_ID')
 		:SetConst('MessageValueParameterName', '__CYTANB_MESSAGE_VALUE')
 

--- a/src/cytanb_annotations.lua
+++ b/src/cytanb_annotations.lua
@@ -7,7 +7,7 @@
 
 ---@alias cytanb_uuid_t number[]
 
----@class cytanb @UUID、ログ、色、メッセージなど、基礎的な機能を提供するモジュール。
+---@class cytanb UUID、ログ、色、メッセージなど、基礎的な機能を提供するモジュール。
 ---@field FatalLogLevel number @致命的なレベルのログを表す定数値。
 ---@field ErrorLogLevel number @エラーレベルのログを表す定数値。
 ---@field WarnLogLevel number @警告レベルのログを表す定数値。
@@ -47,4 +47,3 @@
 ---@field TableFromSerializable fun (serData: table): table @TableToSerializable で変換したテーブルを復元する。
 ---@field EmitMessage fun (name: string, parameterMap: table<string, any>) @パラメーターを JSON シリアライズして `vci.message.Emit` する。`name` はメッセージ名を指定する。`parameterMap` は送信するパラメーターのテーブルを指定する(省略可能)。また、`InstanceID` がパラメーターフィールド `__CYTANB_INSTANCE_ID` として付加されて送信される。
 ---@field OnMessage fun (name: string, callback: fun(sender: table, name: string, parameterMap: table)) @`EmitMessage` したメッセージを受信するコールバック関数を登録する。`name` はメッセージ名を指定する。`callback` 関数に渡される `parameterMap` は JSON データをデシリアライズしたテーブル。また、パラメーターフィールド `__CYTANB_INSTANCE_ID` を利用してメッセージ送信元のインスタンスを識別可能。もしデシリアライズできないデータであった場合は、パラメーターフィールド `__CYTANB_MESSAGE_VALUE` に値がセットされる。
-cytanb = {}


### PR DESCRIPTION
アノテーションは変数の宣言がなくても機能します。
実際にグローバル変数としてアノテーションが表示される必要が無いと考えてプルリクを送りました。