### PR TITLE
Number multiple array bug fix

### DIFF
--- a/src/cytanb.lua
+++ b/src/cytanb.lua
@@ -366,6 +366,9 @@ local cytanb = (function ()
 			refTable[data] = true
 			local serData = {}
 			for k, v in pairs(data) do
+				if type(k) == 'number' then
+					k = cytanb.ArrayNumberTag .. k
+				end
 				if type(v) == 'number' and v < 0 then
 					serData[k .. cytanb.NegativeNumberTag] = tostring(v)
 				else
@@ -385,9 +388,18 @@ local cytanb = (function ()
 			local data = {}
 			for k, v in pairs(serData) do
 				if type(v) == 'string' and string.endsWith(k, cytanb.NegativeNumberTag) then
-					data[string.sub(k, 1, #k - #cytanb.NegativeNumberTag)] = tonumber(v)
-				else
-					data[k] = cytanb.TableFromSerializable(v)
+                    if k:startsWith(cytanb.ArrayNumberTag) then
+                        k = k:sub(1, #k - #cytanb.NegativeNumberTag)
+                        data[tonumber(k:sub(#cytanb.ArrayNumberTag + 1,#k))] = tonumber(v)
+                    else
+                        data[k:sub(1, #k - #cytanb.NegativeNumberTag)] = tonumber(v)
+                    end
+                else
+                    if k:startsWith(cytanb.ArrayNumberTag) then
+                        data[tonumber(k:sub(#cytanb.ArrayNumberTag + 1,#k))] = cytanb.TableFromSerializable(v)
+                    else
+                        data[k] = cytanb.TableFromSerializable(v)
+                    end
 				end
 			end
 			return data
@@ -448,6 +460,7 @@ local cytanb = (function ()
 		:SetConst('ColorBrightnessSamples', 5)
 		:SetConst('ColorMapSize', cytanb.ColorHueSamples * cytanb.ColorSaturationSamples * cytanb.ColorBrightnessSamples)
 		:SetConst('NegativeNumberTag', '#__CYTANB_NEGATIVE_NUMBER')
+		:SetConst('ArrayNumberTag', '#__CYTANB_ARRAY_NUMBER')
 		:SetConst('InstanceIDParameterName', '__CYTANB_INSTANCE_ID')
 		:SetConst('MessageValueParameterName', '__CYTANB_MESSAGE_VALUE')
 

--- a/src/cytanb_annotations.lua
+++ b/src/cytanb_annotations.lua
@@ -19,6 +19,7 @@
 ---@field ColorBrightnessSamples number @デフォルトの明度のサンプル数。
 ---@field ColorMapSize number @デフォルトのカラーマップのサイズ。
 ---@field NegativeNumberTag string @負の数値を示すタグ。
+---@field ArrayNumberTag string @連想配列でなく、keyが数値であることを示すタグ。
 ---@field InstanceIDParameterName string @インスタンス ID のパラーメーター名。
 ---@field MessageValueParameterName string @メッセージ値のパラーメーター名。
 ---@field InstanceID fun (): string @インスタンス ID を取得する。VCI を設置したユーザー以外では、同期完了前は空文字列を返す。


### PR DESCRIPTION
連想配列ではない多重配列が上手くjsonでserialize,parseできない問題のバグ修正。
test = {}
for i = 1,5 do
  test[i] = {}
  for j = 1,5 do
    test[i][j] = "a"
  end
end
これのtest[][]が上手くいかない。